### PR TITLE
Adding graphs to show trip distance vs. duration.

### DIFF
--- a/EDA-cluster.ipynb
+++ b/EDA-cluster.ipynb
@@ -803,18 +803,70 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "Trip Duration vs. Distance"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "#Collect duration data\n",
+    "time_difference_seconds = sample_df.withColumn(\"time_difference_seconds\",\n",
+    "                   (col(\"tpep_dropoff_datetime\") - col(\"tpep_pickup_datetime\"))).collect()\n",
+    "time_difference_seconds_values = [row.time_difference_seconds.total_seconds() for row in time_difference_seconds]\n",
+    "\n",
+    "#Collect trip distance data\n",
+    "trip_distance = sample_df.select(\"trip_distance\").collect()\n",
+    "trip_distance_values = [row[0] for row in trip_distance]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#X/Y plot\n",
+    "plt.figure(figsize=(8, 6))\n",
+    "plt.scatter(time_difference_seconds_values, trip_distance_values, color='blue', s=100, alpha=0.5)\n",
+    "plt.title(\"Relationship between Time Difference (in Seconds) and Trip Distance\")\n",
+    "plt.xlabel(\"Time Difference (Seconds)\")\n",
+    "plt.ylabel(\"Trip Distance\")\n",
+    "plt.grid(True)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(2, 1, figsize=(8, 10))\n",
+    "\n",
+    "# Histogram for trip distance\n",
+    "axs[0].hist(trip_distance_values, bins=100,  color='green')\n",
+    "axs[0].plot(trip_dist_x, trip_dist_y, color='blue')  # KDE line\n",
+    "axs[0].set_title('Histogram of Trip Distance')\n",
+    "axs[0].set_xlabel('Trip Distance')\n",
+    "axs[0].set_ylabel('Frequency')\n",
+    "axs[0].grid(True)\n",
+    "\n",
+    "# Histogram for ride duration\n",
+    "axs[1].hist(time_difference_seconds_values, bins=100, color='orange', alpha=0.7)\n",
+    "axs[1].set_title('Histogram of Ride Duration')\n",
+    "axs[1].set_xlabel('Ride Duration (Seconds)')\n",
+    "axs[1].set_ylabel('Frequency')\n",
+    "axs[1].grid(True)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Graphs the trip distance and duration + an x/y plot of each. The column data is extracted from the sample_df created earlier in the notebook.